### PR TITLE
Migrate to latest Argon 1.6.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,13 +19,14 @@ jobs:
     
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
-          
+          distribution: temurin
+          java-version: 17
+
       - name: Run Android Linter
         run: ./gradlew :pinkman:lint :pinkman-ui:lint
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,8 +33,14 @@ jobs:
       - name: Run Detekt
         run: ./gradlew detekt
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Android Emulator Runner
-        uses: ReactiveCircus/android-emulator-runner@v2.14.3
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
           script: ./gradlew connectedCheck

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   testing:
     name: Code quality and testing
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     
     steps:
       - name: Clone repository

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,22 +1,42 @@
 plugins {
     id(Android.applicationPlugin)
 
-    kotlin(Kotlin.androidPlugin)
-    kotlin(Kotlin.androidExtensions)
-    kotlin(Kotlin.kapt)
+    id(Kotlin.androidPlugin)
+    id(Kotlin.kapt)
 
     id(Dependencies.App.hiltAppPlugin)
 }
 
+kapt {
+    correctErrorTypes = true
+}
+
 android {
+    namespace = "com.redmadrobot.sample"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
     compileSdkVersion(Android.compileSdk)
     buildToolsVersion(Android.buildTools)
 
     defaultConfig {
         applicationId = Android.DefaultConfig.applicationId
 
-        minSdkVersion(Android.DefaultConfig.minSdk)
-        targetSdkVersion(Android.DefaultConfig.targetSdk)
+        minSdk = Android.DefaultConfig.minSdk
+        targetSdk = Android.DefaultConfig.targetSdk
 
         versionCode = Android.DefaultConfig.versionCode
         versionName = Android.DefaultConfig.versionName
@@ -34,19 +54,6 @@ android {
                 )
             }
         }
-
-        compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
-        }
-
-        kotlinOptions {
-            jvmTarget = "1.8"
-        }
-
-        kapt {
-            correctErrorTypes = true
-        }
     }
 }
 
@@ -58,7 +65,7 @@ dependencies {
     implementation(Dependencies.Common.appCompat)
 
     implementation(Dependencies.App.hiltAndroid)
-    implementation(Dependencies.App.hiltLifecycleViewmodel)
+    kapt(Dependencies.App.hiltAndroidCompiler)
 
     implementation(Dependencies.App.navigationFragmentKtx)
     implementation(Dependencies.App.navigationUiKtx)
@@ -69,12 +76,8 @@ dependencies {
     implementation(Dependencies.App.coreKtx)
     implementation(Dependencies.App.constraintlayout)
 
-    kapt(Dependencies.App.hiltCompiler)
-    kapt(Dependencies.App.hiltAndroidCompiler)
-
     testImplementation(TestDependencies.junit)
 
     androidTestImplementation(TestDependencies.junitExt)
     androidTestImplementation(TestDependencies.espresso)
 }
-

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
     namespace = "com.redmadrobot.sample"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {
@@ -25,7 +25,7 @@ android {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(17)
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.redmadrobot.sample"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".App"
@@ -10,7 +9,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.redmadrobot.sample.MainActivity">
+        <activity
+            android:name="com.redmadrobot.sample.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/redmadrobot/sample/MainFragment.kt
+++ b/app/src/main/java/com/redmadrobot/sample/MainFragment.kt
@@ -8,8 +8,9 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.redmadrobot.pinkman.Pinkman
+import com.redmadrobot.sample.databinding.MainFragmentBinding
+import com.redmadrobot.sample.utils.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.main_fragment.*
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -17,6 +18,8 @@ class MainFragment : Fragment() {
 
     @Inject
     lateinit var pinkman: Pinkman
+
+    private val viewBinding by viewBinding(MainFragmentBinding::bind)
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -34,22 +37,22 @@ class MainFragment : Fragment() {
         return inflater.inflate(R.layout.main_fragment, container, false)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(viewBinding) {
         super.onViewCreated(view, savedInstanceState)
 
         if (pinkman.isPinSet()) {
-            pin_button.text = "Remove PIN"
-            pin_button.setOnClickListener {
+            pinButton.text = "Remove PIN"
+            pinButton.setOnClickListener {
                 pinkman.removePin()
 
                 parentFragmentManager.beginTransaction()
-                    .detach(this)
-                    .attach(this)
+                    .detach(this@MainFragment)
+                    .attach(this@MainFragment)
                     .commit()
             }
         } else {
-            pin_button.text = "Create PIN"
-            pin_button.setOnClickListener { findNavController().navigate(R.id.createPinFragment) }
+            pinButton.text = "Create PIN"
+            pinButton.setOnClickListener { findNavController().navigate(R.id.createPinFragment) }
         }
     }
 }

--- a/app/src/main/java/com/redmadrobot/sample/create_pin/CreatePinFragment.kt
+++ b/app/src/main/java/com/redmadrobot/sample/create_pin/CreatePinFragment.kt
@@ -9,13 +9,16 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.redmadrobot.pinkman_ui.KeyClickListener
 import com.redmadrobot.sample.R
+import com.redmadrobot.sample.databinding.CreatePinFragmentBinding
+import com.redmadrobot.sample.utils.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.create_pin_fragment.*
 
 @AndroidEntryPoint
 class CreatePinFragment : Fragment() {
 
     private val viewModel: CreatePinViewModel by viewModels()
+
+    private val viewBinding by viewBinding(CreatePinFragmentBinding::bind)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -25,14 +28,14 @@ class CreatePinFragment : Fragment() {
         return inflater.inflate(R.layout.create_pin_fragment, container, false)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(viewBinding) {
         super.onViewCreated(view, savedInstanceState)
 
         viewModel.pinIsCreated.observe(viewLifecycleOwner) {
             findNavController().popBackStack(R.id.mainFragment, false)
         }
 
-        pin_view.onFilledListener = { viewModel.createPin(it) }
-        keyboard.keyClickListener = KeyClickListener { pin_view.add(it) }
+        pinView.onFilledListener = { viewModel.createPin(it) }
+        keyboard.keyClickListener = KeyClickListener { pinView.add(it) }
     }
 }

--- a/app/src/main/java/com/redmadrobot/sample/create_pin/CreatePinViewModel.kt
+++ b/app/src/main/java/com/redmadrobot/sample/create_pin/CreatePinViewModel.kt
@@ -1,11 +1,13 @@
 package com.redmadrobot.sample.create_pin
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.redmadrobot.pinkman.Pinkman
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class CreatePinViewModel @ViewModelInject constructor(private val pinkman: Pinkman) : ViewModel() {
+@HiltViewModel
+class CreatePinViewModel @Inject constructor(private val pinkman: Pinkman) : ViewModel() {
 
     val pinIsCreated = MutableLiveData<Boolean>()
 

--- a/app/src/main/java/com/redmadrobot/sample/input_pin/InputPinFragment.kt
+++ b/app/src/main/java/com/redmadrobot/sample/input_pin/InputPinFragment.kt
@@ -12,13 +12,16 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.redmadrobot.pinkman_ui.KeyClickListener
 import com.redmadrobot.sample.R
+import com.redmadrobot.sample.databinding.InputPinFragmentBinding
+import com.redmadrobot.sample.utils.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.create_pin_fragment.*
 
 @AndroidEntryPoint
 class InputPinFragment : Fragment() {
 
     private val viewModel: InputPinViewModel by viewModels()
+
+    private val viewBinding by viewBinding(InputPinFragmentBinding::bind)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -28,7 +31,7 @@ class InputPinFragment : Fragment() {
         return inflater.inflate(R.layout.input_pin_fragment, container, false)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(viewBinding) {
         super.onViewCreated(view, savedInstanceState)
 
         viewModel.pinIsValid.observe(viewLifecycleOwner) { isValid ->
@@ -37,11 +40,11 @@ class InputPinFragment : Fragment() {
             } else {
                 Toast.makeText(context, "Invalid PIN", Toast.LENGTH_SHORT).show()
                 @Suppress("MagicNumber")
-                Handler(Looper.getMainLooper()).postDelayed({ pin_view.empty() }, 500)
+                Handler(Looper.getMainLooper()).postDelayed({ pinView.empty() }, 500)
             }
         }
 
-        pin_view.onFilledListener = { viewModel.validatePin(it) }
-        keyboard.keyClickListener = KeyClickListener { pin_view.add(it) }
+        pinView.onFilledListener = { viewModel.validatePin(it) }
+        keyboard.keyClickListener = KeyClickListener { pinView.add(it) }
     }
 }

--- a/app/src/main/java/com/redmadrobot/sample/input_pin/InputPinViewModel.kt
+++ b/app/src/main/java/com/redmadrobot/sample/input_pin/InputPinViewModel.kt
@@ -1,11 +1,13 @@
 package com.redmadrobot.sample.input_pin
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.redmadrobot.pinkman.Pinkman
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class InputPinViewModel @ViewModelInject constructor(private val pinkman: Pinkman) : ViewModel() {
+@HiltViewModel
+class InputPinViewModel @Inject constructor(private val pinkman: Pinkman) : ViewModel() {
 
     val pinIsValid = MutableLiveData<Boolean>()
 

--- a/app/src/main/java/com/redmadrobot/sample/internal/HiltModule.kt
+++ b/app/src/main/java/com/redmadrobot/sample/internal/HiltModule.kt
@@ -5,11 +5,11 @@ import com.redmadrobot.pinkman.Pinkman
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 object HiltModule {
 
     @Singleton

--- a/app/src/main/java/com/redmadrobot/sample/utils/FragmentViewBindingDelegate.kt
+++ b/app/src/main/java/com/redmadrobot/sample/utils/FragmentViewBindingDelegate.kt
@@ -1,0 +1,59 @@
+package com.redmadrobot.sample.utils
+
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+internal fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T) =
+    FragmentViewBindingDelegate(this, viewBindingFactory)
+
+internal class FragmentViewBindingDelegate<T : ViewBinding>(
+    fragment: Fragment,
+    val viewBindingFactory: (View) -> T
+) : ReadOnlyProperty<Fragment, T> {
+    private var binding: T? = null
+
+    init {
+        val callback = object : FragmentManager.FragmentLifecycleCallbacks() {
+            override fun onFragmentViewDestroyed(fm: FragmentManager, f: Fragment) {
+                super.onFragmentViewDestroyed(fm, f)
+                if (f === fragment) {
+                    binding = null
+                }
+            }
+        }
+
+        fragment.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onCreate(owner: LifecycleOwner) {
+                    fragment.parentFragmentManager
+                        .registerFragmentLifecycleCallbacks(callback, false)
+                }
+
+                override fun onDestroy(owner: LifecycleOwner) {
+                    fragment.parentFragmentManager
+                        .unregisterFragmentLifecycleCallbacks(callback)
+                }
+            }
+        )
+    }
+
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
+        binding?.let {
+            return it
+        }
+
+        val lifecycle = thisRef.viewLifecycleOwner.lifecycle
+        check(lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
+            "Should not attempt to get bindings when Fragment views are destroyed."
+        }
+
+        return viewBindingFactory(thisRef.requireView()).also { this.binding = it }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,6 @@ buildscript {
     dependencies {
         classpath(Android.gradlePlugin)
         classpath(Kotlin.gradlePlugin)
-
-        classpath(GradlePlugin.Bintray.gradlePlugin)
-
         classpath(Dependencies.App.hiltGradlePlugin)
     }
 }
@@ -33,12 +30,6 @@ allprojects {
 subprojects {
     apply(plugin = GradlePlugin.Detekt.plugin)
 
-    tasks {
-        withType<io.gitlab.arturbosch.detekt.Detekt> {
-            this.jvmTarget = "1.8"
-        }
-    }
-
     detekt {
         config = rootProject.files("detekt/config.yml")
         baseline = rootProject.file("detekt/detekt-baseline.xml")
@@ -55,10 +46,9 @@ subprojects {
 
     dependencies {
         detektPlugins(GradlePlugin.Detekt.formattingPlugin)
-
     }
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,5 +19,12 @@ gradlePlugin {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:4.1.2")
+    implementation("com.android.tools.build:gradle:8.11.1")
+}
+
+configurations.all {
+    resolutionStrategy {
+        // Force the version Hilt needs to run its tasks
+        force("com.squareup:javapoet:1.13.0")
+    }
 }

--- a/buildSrc/src/main/java/Android.kt
+++ b/buildSrc/src/main/java/Android.kt
@@ -2,10 +2,10 @@ import java.io.File
 import java.util.*
 
 object Android {
-    private const val pluginVersion = "4.1.3"
+    private const val pluginVersion = "8.11.1"
 
-    const val compileSdk = 30
-    const val buildTools = "30.0.1"
+    const val compileSdk = 36
+    const val buildTools = "36.0.0"
 
     const val gradlePlugin = "com.android.tools.build:gradle:$pluginVersion"
     const val applicationPlugin = "com.android.application"
@@ -13,7 +13,7 @@ object Android {
 
     object DefaultConfig {
         const val minSdk = 23
-        const val targetSdk = 30
+        const val targetSdk = 36
 
         const val applicationId = "com.redmadrobot.pinkman_sample"
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,7 +1,7 @@
 object Dependencies {
     object Common {
         private object Versions {
-            const val appCompat = "1.2.0"
+            const val appCompat = "1.7.0"
         }
 
         const val appCompat = "androidx.appcompat:appcompat:${Versions.appCompat}"
@@ -10,7 +10,7 @@ object Dependencies {
     object Lib {
         private object Versions {
             const val securityCrypto = "1.0.0"
-            const val argon2 = "1.3.0"
+            const val argon2 = "1.6.0"
             const val coroutines = "1.4.2"
             const val rxJava3 = "3.1.4"
         }
@@ -23,24 +23,19 @@ object Dependencies {
 
     object App {
         private object Versions {
-            const val daggerVersion = "2.30.1-alpha"
-            const val hiltLifecycleViewmodel = "1.0.0-alpha01"
+            const val hilt = "2.57"
 
-            const val navigationFragmentKtx = "2.3.0-rc01"
-            const val navigationUiKtx = "2.3.0-rc01"
+            const val navigationFragmentKtx = "2.9.7"
+            const val navigationUiKtx = "2.9.7"
 
             const val lifecycleViewmodelKtx = "2.2.0"
             const val lifecycleLivedataKtx = "2.2.0"
 
             const val coreKtx = "1.3.0"
             const val constraintlayout = "1.1.3"
-
-            const val hiltCompiler = "1.0.0-alpha01"
-            const val hiltAndroidCompiler = "2.30.1-alpha"
         }
 
-        const val hiltAndroid = "com.google.dagger:hilt-android:${Versions.daggerVersion}"
-        const val hiltLifecycleViewmodel = "androidx.hilt:hilt-lifecycle-viewmodel:${Versions.hiltLifecycleViewmodel}"
+        const val hiltAndroid = "com.google.dagger:hilt-android:${Versions.hilt}"
 
         const val navigationFragmentKtx = "androidx.navigation:navigation-fragment-ktx:${Versions.navigationFragmentKtx}"
         const val navigationUiKtx = "androidx.navigation:navigation-ui-ktx:${Versions.navigationUiKtx}"
@@ -51,9 +46,8 @@ object Dependencies {
         const val coreKtx = "androidx.core:core-ktx:${Versions.coreKtx}"
         const val constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.constraintlayout}"
 
-        const val hiltCompiler = "androidx.hilt:hilt-compiler:${Versions.hiltCompiler}"
-        const val hiltAndroidCompiler = "com.google.dagger:hilt-android-compiler:${Versions.hiltAndroidCompiler}"
+        const val hiltAndroidCompiler = "com.google.dagger:hilt-android-compiler:${Versions.hilt}"
         const val hiltAppPlugin = "dagger.hilt.android.plugin"
-        const val hiltGradlePlugin = "com.google.dagger:hilt-android-gradle-plugin:${Versions.daggerVersion}"
+        const val hiltGradlePlugin = "com.google.dagger:hilt-android-gradle-plugin:${Versions.hilt}"
     }
 }

--- a/buildSrc/src/main/java/GradlePlugin.kt
+++ b/buildSrc/src/main/java/GradlePlugin.kt
@@ -15,9 +15,4 @@ object GradlePlugin {
 
         const val formattingPlugin = "io.gitlab.arturbosch.detekt:detekt-formatting:$version"
     }
-
-    object Bintray {
-        const val gradlePlugin = "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5"
-    }
-
 }

--- a/buildSrc/src/main/java/Kotlin.kt
+++ b/buildSrc/src/main/java/Kotlin.kt
@@ -1,11 +1,9 @@
 object Kotlin {
-    private const val version = "1.4.21"
+    private const val version = "2.2.0"
 
     const val stdLib = "org.jetbrains.kotlin:kotlin-stdlib:$version"
     const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
 
-    const val androidPlugin = "android"
-    const val androidExtensions = "android.extensions"
-    const val kapt = "kapt"
-
+    const val androidPlugin = "kotlin-android"
+    const val kapt = "kotlin-kapt"
 }

--- a/buildSrc/src/main/java/TestDependencies.kt
+++ b/buildSrc/src/main/java/TestDependencies.kt
@@ -1,7 +1,7 @@
 object TestDependencies {
     private object Versions {
         const val junit = "4.13"
-        const val junitExt = "1.1.2"
+        const val junitExt = "1.1.3"
         const val espresso = "3.3.0"
         const val assertjCore = "3.18.1"
         const val mockitoCore = "3.6.28"

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Xmx2048m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/gradle/publish.properties
+++ b/gradle/publish.properties
@@ -7,4 +7,4 @@ sonatype_repo=https://s01.oss.sonatype.org/service/local/staging/deploy/maven2
 license_name=MIT
 license_url=http://opensource.org/licenses/MIT
 
-lib_version=1.3.2
+lib_version=1.4.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pinkman-coroutines/build.gradle.kts
+++ b/pinkman-coroutines/build.gradle.kts
@@ -9,13 +9,13 @@ android {
     namespace = "com.redmadrobot.pinkman_coroutines"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(17)
         }
     }
 

--- a/pinkman-coroutines/build.gradle.kts
+++ b/pinkman-coroutines/build.gradle.kts
@@ -1,17 +1,28 @@
 plugins {
     id(Android.libraryPlugin)
-    kotlin(Kotlin.androidPlugin)
+    id(Kotlin.androidPlugin)
+    id("maven-publish")
     id("publishPlugin")
 }
 
 android {
+    namespace = "com.redmadrobot.pinkman_coroutines"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
     compileSdkVersion(Android.compileSdk)
 
     defaultConfig {
-        minSdkVersion(Android.DefaultConfig.minSdk)
-        targetSdkVersion(Android.DefaultConfig.targetSdk)
-        versionCode = Android.DefaultConfig.versionCode
-        versionName = Android.DefaultConfig.versionName
+        minSdk = Android.DefaultConfig.minSdk
 
         testInstrumentationRunner = Android.DefaultConfig.instrumentationRunner
 
@@ -32,18 +43,13 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
-    packagingOptions {
-        exclude("META-INF/AL2.0")
-        exclude("META-INF/LGPL2.1")
+    packaging {
+        resources {
+            excludes += setOf(
+                "META-INF/AL2.0",
+                "META-INF/LGPL2.1"
+            )
+        }
     }
 }
 

--- a/pinkman-coroutines/src/androidTest/java/com/redmadrobot/pinkman_coroutines/CoroutinesPinkmanTest.kt
+++ b/pinkman-coroutines/src/androidTest/java/com/redmadrobot/pinkman_coroutines/CoroutinesPinkmanTest.kt
@@ -5,9 +5,10 @@ import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.redmadrobot.pinkman.Pinkman
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert
@@ -15,13 +16,13 @@ import org.junit.Before
 import org.junit.Test
 import java.io.File
 
-
+@OptIn(ExperimentalCoroutinesApi::class)
 @SmallTest
 class CoroutinesPinkmanTest {
     private lateinit var applicationContext: Context
     private lateinit var pinkman: Pinkman
 
-    private val testDispatcher = TestCoroutineDispatcher()
+    private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setUp() {
@@ -34,12 +35,11 @@ class CoroutinesPinkmanTest {
     fun tearDown() {
         File(applicationContext.filesDir, "pinkman").delete()
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 
     @Test
     fun createPin() {
-        runBlockingTest {
+        runTest {
             pinkman.createPinAsync("0000", coroutineContext = testDispatcher)
 
             Assert.assertTrue(
@@ -51,7 +51,7 @@ class CoroutinesPinkmanTest {
 
     @Test
     fun changePin() {
-        runBlockingTest {
+        runTest {
             pinkman.createPinAsync("0000", coroutineContext = testDispatcher)
 
             pinkman.changePinAsync("0000", "1111", coroutineContext = testDispatcher)
@@ -62,7 +62,7 @@ class CoroutinesPinkmanTest {
 
     @Test
     fun isValidPin() {
-        runBlockingTest {
+        runTest {
             pinkman.createPinAsync("0000", coroutineContext = testDispatcher)
 
             Assert.assertTrue(pinkman.isValidPinAsync("0000", coroutineContext = testDispatcher))

--- a/pinkman-coroutines/src/main/AndroidManifest.xml
+++ b/pinkman-coroutines/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<manifest package="com.redmadrobot.pinkman_coroutines" />
-

--- a/pinkman-rx3/build.gradle.kts
+++ b/pinkman-rx3/build.gradle.kts
@@ -1,17 +1,28 @@
 plugins {
     id(Android.libraryPlugin)
-    kotlin(Kotlin.androidPlugin)
+    id(Kotlin.androidPlugin)
+    id("maven-publish")
     id("publishPlugin")
 }
 
 android {
+    namespace = "com.redmadrobot.pinkman_rx3"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
     compileSdkVersion(Android.compileSdk)
 
     defaultConfig {
-        minSdkVersion(Android.DefaultConfig.minSdk)
-        targetSdkVersion(Android.DefaultConfig.targetSdk)
-        versionCode = Android.DefaultConfig.versionCode
-        versionName = Android.DefaultConfig.versionName
+        minSdk = Android.DefaultConfig.minSdk
 
         testInstrumentationRunner = Android.DefaultConfig.instrumentationRunner
 
@@ -32,18 +43,13 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
-    packagingOptions {
-        exclude("META-INF/AL2.0")
-        exclude("META-INF/LGPL2.1")
+    packaging {
+        resources {
+            excludes += setOf(
+                "META-INF/AL2.0",
+                "META-INF/LGPL2.1"
+            )
+        }
     }
 }
 

--- a/pinkman-rx3/build.gradle.kts
+++ b/pinkman-rx3/build.gradle.kts
@@ -9,13 +9,13 @@ android {
     namespace = "com.redmadrobot.pinkman_rx3"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(17)
         }
     }
 

--- a/pinkman-rx3/src/main/AndroidManifest.xml
+++ b/pinkman-rx3/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.redmadrobot.pinkman_rx3"/>

--- a/pinkman-ui/build.gradle.kts
+++ b/pinkman-ui/build.gradle.kts
@@ -1,17 +1,28 @@
 plugins {
     id(Android.libraryPlugin)
-    kotlin(Kotlin.androidPlugin)
+    id(Kotlin.androidPlugin)
+    id("maven-publish")
     id("publishPlugin")
 }
 
 android {
+    namespace = "com.redmadrobot.pinkman_ui"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
     compileSdkVersion(Android.compileSdk)
 
     defaultConfig {
-        minSdkVersion(Android.DefaultConfig.minSdk)
-        targetSdkVersion(Android.DefaultConfig.targetSdk)
-        versionCode = Android.DefaultConfig.versionCode
-        versionName = Android.DefaultConfig.versionName
+        minSdk = Android.DefaultConfig.minSdk
 
         testInstrumentationRunner = Android.DefaultConfig.instrumentationRunner
 
@@ -30,15 +41,6 @@ android {
                 Android.Proguard.projectRules
             )
         }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 }
 

--- a/pinkman-ui/build.gradle.kts
+++ b/pinkman-ui/build.gradle.kts
@@ -9,13 +9,13 @@ android {
     namespace = "com.redmadrobot.pinkman_ui"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(17)
         }
     }
 

--- a/pinkman-ui/src/main/AndroidManifest.xml
+++ b/pinkman-ui/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<manifest package="com.redmadrobot.pinkman_ui" />
-

--- a/pinkman/build.gradle.kts
+++ b/pinkman/build.gradle.kts
@@ -9,13 +9,13 @@ android {
     namespace = "com.redmadrobot.pinkman"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(17)
         }
     }
 

--- a/pinkman/build.gradle.kts
+++ b/pinkman/build.gradle.kts
@@ -1,17 +1,28 @@
 plugins {
     id(Android.libraryPlugin)
-    kotlin(Kotlin.androidPlugin)
+    id(Kotlin.androidPlugin)
+    id("maven-publish")
     id("publishPlugin")
 }
 
 android {
+    namespace = "com.redmadrobot.pinkman"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
     compileSdkVersion(Android.compileSdk)
 
     defaultConfig {
-        minSdkVersion(Android.DefaultConfig.minSdk)
-        targetSdkVersion(Android.DefaultConfig.targetSdk)
-        versionCode = Android.DefaultConfig.versionCode
-        versionName = Android.DefaultConfig.versionName
+        minSdk = Android.DefaultConfig.minSdk
 
         testInstrumentationRunner = Android.DefaultConfig.instrumentationRunner
 
@@ -32,17 +43,10 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
-    packagingOptions {
-        exclude("META-INF/LICENSE*")
+    packaging {
+        resources {
+            excludes += setOf("META-INF/LICENSE*")
+        }
     }
 }
 

--- a/pinkman/src/main/AndroidManifest.xml
+++ b/pinkman/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<manifest package="com.redmadrobot.pinkman" />
-

--- a/pinkman/src/main/java/com/redmadrobot/pinkman/Pinkman.kt
+++ b/pinkman/src/main/java/com/redmadrobot/pinkman/Pinkman.kt
@@ -159,7 +159,7 @@ class Pinkman(
         }
     }
 
-    private inline fun checkBlacklisted(pin: String) {
+    private fun checkBlacklisted(pin: String) {
         if (pinBlacklist != null && pinBlacklist.contains(pin)) {
             throw BlacklistedPinException()
         }


### PR DESCRIPTION
Migration to latest tools for Argon 1.6.0 library usage.
With this changes we can use this lib without 16kb pages alingement issue.

Kotlin 2.2.0
Java 21
Target / Compile SDK 36
Gradle 8

CI (test.yml) not checked (need help)
Distribution (publishing) not checked (need help)

Dependencies changes should be reviewed

I checked build via latest Android studio

Build hasn't work without this one  - force("com.squareup:javapoet:1.13.0")
didn't find poisoned dependency