### PR TITLE
 Quick fixes

### DIFF
--- a/app/src/main/java/com/redmadrobot/sample/MainFragment.kt
+++ b/app/src/main/java/com/redmadrobot/sample/MainFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commitNow
 import androidx.navigation.fragment.findNavController
 import com.redmadrobot.pinkman.Pinkman
 import com.redmadrobot.sample.databinding.MainFragmentBinding
@@ -45,10 +46,10 @@ class MainFragment : Fragment() {
             pinButton.setOnClickListener {
                 pinkman.removePin()
 
-                parentFragmentManager.beginTransaction()
-                    .detach(this@MainFragment)
-                    .attach(this@MainFragment)
-                    .commit()
+                parentFragmentManager.apply {
+                    commitNow { detach(this@MainFragment) }
+                    commitNow { attach(this@MainFragment) }
+                }
             }
         } else {
             pinButton.text = "Create PIN"

--- a/buildSrc/src/main/java/PublishPlugin.kt
+++ b/buildSrc/src/main/java/PublishPlugin.kt
@@ -1,17 +1,22 @@
 package com.redmadrobot.build
 
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.getByName
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.register
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
 import java.io.File
-import java.util.*
+import java.util.Properties
 
 class PublishPlugin : Plugin<Project> {
     lateinit var projectDir: File
@@ -33,6 +38,10 @@ class PublishPlugin : Plugin<Project> {
         projectDir = target.projectDir
 
         with(target) {
+            extensions.getByName<LibraryExtension>("android").publishing {
+                singleVariant("release")
+            }
+
             afterEvaluate {
                 configurePublishing()
                 configureSigning()


### PR DESCRIPTION
 Quick fixes

  - PublishPlugin: add singleVariant("release") required by AGP 7.1+ for Maven publication to work; clean up wildcard imports
  - MainFragment: replace chained detach/attach transaction with separate commitNow calls via KTX extension commitNow calls via KTX extension